### PR TITLE
Forward arguments to KakouneClient from KakouneCli

### DIFF
--- a/src/kakounecli.cpp
+++ b/src/kakounecli.cpp
@@ -4,12 +4,19 @@ KakouneCli::KakouneCli(const QString &service_name) : m_dbusiface(service_name, 
 {
 }
 
-int KakouneCli::run(QList<QString> command)
+int KakouneCli::run(QStringList command)
 {
     QString &command_name = command[0];
     if (command_name == "new-client")
     {
-        m_dbusiface.call("newClient");
+        if (command.size() == 1)
+        {
+            m_dbusiface.call("newClient");
+        }
+        else
+        {
+            m_dbusiface.call("newClient", command.sliced(1).join(" "));
+        }
     }
     else
     {

--- a/src/kakounecli.hpp
+++ b/src/kakounecli.hpp
@@ -10,7 +10,7 @@ class KakouneCli
   public:
     KakouneCli(const QString &service_name);
 
-    int run(QList<QString> command);
+    int run(QStringList command);
 
   private:
     QDBusInterface m_dbusiface;

--- a/src/kakouneclient.cpp
+++ b/src/kakouneclient.cpp
@@ -65,7 +65,11 @@ void KakouneClient::handleRequest(QJsonObject request)
     }
 }
 
-KakouneClient::KakouneClient(const QString &session_id)
+KakouneClient::KakouneClient(const QString &session_id) : KakouneClient(session_id, "")
+{
+}
+
+KakouneClient::KakouneClient(const QString &session_id, QString arguments)
 {
     connect(&m_process, &QProcess::readyReadStandardOutput, [=]() {
         QByteArray buffer = m_process.readAllStandardOutput();
@@ -84,7 +88,16 @@ KakouneClient::KakouneClient(const QString &session_id)
 
     connect(&m_process, &QProcess::finished, this, &KakouneClient::finished);
 
-    m_process.start("kak", {"-ui", "json", "-c", session_id});
+    QStringList process_arguments;
+    qDebug() << arguments;
+    process_arguments << "-ui"
+                      << "json"
+                      << "-c" << session_id;
+    if (!arguments.isEmpty())
+    {
+        process_arguments << "-e" << arguments;
+    }
+    m_process.start("kak", process_arguments);
 }
 
 KakouneClient::~KakouneClient()

--- a/src/kakouneclient.hpp
+++ b/src/kakouneclient.hpp
@@ -11,6 +11,7 @@ class KakouneClient : public QObject
     Q_OBJECT
   public:
     KakouneClient(const QString &session_id);
+    KakouneClient(const QString &session_id, QString arguments);
     ~KakouneClient();
 
     void sendKeys(const QString &key);

--- a/src/kakounewidget.cpp
+++ b/src/kakounewidget.cpp
@@ -1,13 +1,18 @@
 #include "kakounewidget.hpp"
 #include "statusbar.hpp"
 
-KakouneWidget::KakouneWidget(const QString &session_id, DrawOptions *draw_options, QWidget *parent) : QWidget(parent)
+KakouneWidget::KakouneWidget(const QString &session_id, DrawOptions *draw_options, QWidget *parent)
+    : KakouneWidget(session_id, draw_options, "", parent)
 {
-    qDebug("Constructing kakounewidget");
+}
 
+KakouneWidget::KakouneWidget(const QString &session_id, DrawOptions *draw_options, QString client_arguments,
+                             QWidget *parent)
+    : QWidget(parent)
+{
     m_draw_options = draw_options;
 
-    m_client = new KakouneClient(session_id);
+    m_client = new KakouneClient(session_id, client_arguments);
     connect(m_client, &KakouneClient::refresh, this, &KakouneWidget::clientRefreshed);
     connect(m_client, &KakouneClient::finished, this, &KakouneWidget::finished);
 

--- a/src/kakounewidget.hpp
+++ b/src/kakounewidget.hpp
@@ -13,6 +13,8 @@ class KakouneWidget : public QWidget
     Q_OBJECT
   public:
     KakouneWidget(const QString &session_id, DrawOptions *draw_options, QWidget *parent = nullptr);
+    KakouneWidget(const QString &session_id, DrawOptions *draw_options, QString client_arguments,
+                  QWidget *parent = nullptr);
     ~KakouneWidget();
 
     KakouneClient *getClient();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
     {
         KakouneCli cli(DBUS_SERVICE_NAME);
 
-        QList<QString> command;
+        QStringList command;
         for (int i = 2; i < argc; i++)
         {
             command.append(argv[i]);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -27,7 +27,12 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 
 void MainWindow::newClient()
 {
-    KakouneWidget *kakwidget = new KakouneWidget(m_session->getSessionId(), m_draw_options, m_root);
+    newClient("");
+}
+
+void MainWindow::newClient(const QString &arguments)
+{
+    KakouneWidget *kakwidget = new KakouneWidget(m_session->getSessionId(), m_draw_options, arguments, m_root);
     connect(kakwidget, &KakouneWidget::finished, m_root, [=]() {
         kakwidget->setParent(nullptr);
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -16,6 +16,7 @@ class MainWindow : public QMainWindow
 
   public slots:
     void newClient();
+    void newClient(const QString &arguments);
 
   protected:
     void closeEvent(QCloseEvent *ev) override;


### PR DESCRIPTION
You can now do `kak-qt cli new-client rename-client james`, and the arguments `rename-client james` would be passed to the new client