### PR TITLE
Add focus command to kakounecli

### DIFF
--- a/src/kakounecli.cpp
+++ b/src/kakounecli.cpp
@@ -18,6 +18,14 @@ int KakouneCli::run(QStringList command)
             m_dbusiface.call("newClient", command.sliced(1).join(" "));
         }
     }
+    else if (command_name == "focus")
+    {
+        if (command.size() != 2)
+        {
+            return 1;
+        }
+        m_dbusiface.call("focusWindow", command[1]);
+    }
     else
     {
         return 1;

--- a/src/kakouneclient.cpp
+++ b/src/kakouneclient.cpp
@@ -69,7 +69,12 @@ KakouneClient::KakouneClient(const QString &session_id) : KakouneClient(session_
 {
 }
 
-KakouneClient::KakouneClient(const QString &session_id, QString arguments)
+KakouneClient::KakouneClient(const QString &session_id, QString arguments) : KakouneClient(session_id, arguments, {})
+{
+}
+
+KakouneClient::KakouneClient(const QString &session_id, QString arguments,
+                             QList<QPair<QString, QString>> environment_variables)
 {
     connect(&m_process, &QProcess::readyReadStandardOutput, [=]() {
         QByteArray buffer = m_process.readAllStandardOutput();
@@ -88,8 +93,14 @@ KakouneClient::KakouneClient(const QString &session_id, QString arguments)
 
     connect(&m_process, &QProcess::finished, this, &KakouneClient::finished);
 
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    for (auto variable : environment_variables)
+    {
+        env.insert(variable.first, variable.second);
+    }
+    m_process.setProcessEnvironment(env);
+
     QStringList process_arguments;
-    qDebug() << arguments;
     process_arguments << "-ui"
                       << "json"
                       << "-c" << session_id;

--- a/src/kakouneclient.hpp
+++ b/src/kakouneclient.hpp
@@ -12,6 +12,7 @@ class KakouneClient : public QObject
   public:
     KakouneClient(const QString &session_id);
     KakouneClient(const QString &session_id, QString arguments);
+    KakouneClient(const QString &session_id, QString arguments, QList<QPair<QString, QString>> environment_variables);
     ~KakouneClient();
 
     void sendKeys(const QString &key);

--- a/src/kakounewidget.cpp
+++ b/src/kakounewidget.cpp
@@ -10,9 +10,10 @@ KakouneWidget::KakouneWidget(const QString &session_id, DrawOptions *draw_option
                              QWidget *parent)
     : QWidget(parent)
 {
+    m_id = QUuid::createUuid();
     m_draw_options = draw_options;
 
-    m_client = new KakouneClient(session_id, client_arguments);
+    m_client = new KakouneClient(session_id, client_arguments, {{"KAKQT_WINDOW_ID", m_id.toString()}});
     connect(m_client, &KakouneClient::refresh, this, &KakouneWidget::clientRefreshed);
     connect(m_client, &KakouneClient::finished, this, &KakouneWidget::finished);
 
@@ -30,6 +31,7 @@ KakouneWidget::KakouneWidget(const QString &session_id, DrawOptions *draw_option
     layout->addWidget(m_textedit);
     layout->addWidget(status_bar);
 
+    setFocusProxy(m_textedit);
     this->setLayout(layout);
 }
 
@@ -41,6 +43,11 @@ QSize KakouneWidget::sizeHint() const
 KakouneWidget::~KakouneWidget()
 {
     delete m_client;
+}
+
+QUuid KakouneWidget::getID()
+{
+    return m_id;
 }
 
 KakouneClient *KakouneWidget::getClient()

--- a/src/kakounewidget.hpp
+++ b/src/kakounewidget.hpp
@@ -17,6 +17,7 @@ class KakouneWidget : public QWidget
                   QWidget *parent = nullptr);
     ~KakouneWidget();
 
+    QUuid getID();
     KakouneClient *getClient();
 
     QSize sizeHint() const override;
@@ -28,6 +29,7 @@ class KakouneWidget : public QWidget
     void refresh();
 
   private:
+    QUuid m_id;
     KakouneClient *m_client;
 
     KakouneTextEdit *m_textedit;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,5 +1,4 @@
 #include "mainwindow.hpp"
-#include "kakounewidget.hpp"
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 {
@@ -35,6 +34,7 @@ void MainWindow::newClient(const QString &arguments)
     KakouneWidget *kakwidget = new KakouneWidget(m_session->getSessionId(), m_draw_options, arguments, m_root);
     connect(kakwidget, &KakouneWidget::finished, m_root, [=]() {
         kakwidget->setParent(nullptr);
+        m_windows.removeOne(kakwidget);
 
         if (m_root->count() == 0)
         {
@@ -42,5 +42,18 @@ void MainWindow::newClient(const QString &arguments)
         }
     });
 
+    m_windows.append(kakwidget);
     m_root->addWidget(kakwidget);
+}
+
+void MainWindow::focusWindow(const QString &uuid)
+{
+    for (KakouneWidget *window : m_windows)
+    {
+        if (window->getID().toString() == uuid)
+        {
+            window->setFocus();
+            return;
+        }
+    }
 }

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -3,6 +3,7 @@
 
 #include "drawoptions.hpp"
 #include "kakounesession.hpp"
+#include "kakounewidget.hpp"
 #include <QMainWindow>
 #include <QtWidgets>
 
@@ -17,6 +18,7 @@ class MainWindow : public QMainWindow
   public slots:
     void newClient();
     void newClient(const QString &arguments);
+    void focusWindow(const QString &uuid);
 
   protected:
     void closeEvent(QCloseEvent *ev) override;
@@ -24,6 +26,8 @@ class MainWindow : public QMainWindow
   private:
     QSplitter *m_root;
     KakouneSession *m_session;
+
+    QList<KakouneWidget *> m_windows;
 
     DrawOptions *m_draw_options;
 };


### PR DESCRIPTION
Use `kak-qt cli focus <window-uuid>` to focus a certain window/widget running in kak-qt. The window uuid will be passed to the kakoune client as an environment variable (KAKQT_WINDOW_ID)