### PR TITLE
Use sockets for IPC instead of DBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets DBus)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Network)
 qt_standard_project_setup()
 
 qt_add_executable(kak-qt
@@ -18,6 +18,7 @@ qt_add_executable(kak-qt
     src/rpc/rpc.cpp
     src/keybindings.cpp
     src/drawoptions.cpp
+    src/kakouneserver.cpp
     src/kakounesession.cpp
     src/kakouneclient.cpp
     src/kakounecli.cpp
@@ -30,7 +31,7 @@ qt_add_executable(kak-qt
     src/main.cpp
 )
 
-target_link_libraries(kak-qt PRIVATE Qt6::Widgets Qt6::DBus)
+target_link_libraries(kak-qt PRIVATE Qt6::Widgets Qt6::Network)
 
 set_target_properties(kak-qt PROPERTIES
     WIN32_EXECUTABLE ON

--- a/src/kakounecli.cpp
+++ b/src/kakounecli.cpp
@@ -4,11 +4,12 @@
 KakouneCli::KakouneCli()
 {
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-    QString session_id = env.value("KAKQT_SESSION_ID") ;
+    QString session_id = env.value("KAKQT_SESSION_ID");
 
     m_socket = new QLocalSocket();
     m_socket->connectToServer("KakouneQt." + session_id);
-    if (!m_socket->waitForConnected()) {
+    if (!m_socket->waitForConnected())
+    {
         qDebug() << "Failed to connect to server:" << m_socket->errorString();
         return;
     }
@@ -16,7 +17,7 @@ KakouneCli::KakouneCli()
 
 KakouneCli::~KakouneCli()
 {
-  m_socket->disconnectFromServer();
+    m_socket->disconnectFromServer();
 }
 
 int KakouneCli::run(QStringList command)

--- a/src/kakounecli.cpp
+++ b/src/kakounecli.cpp
@@ -1,11 +1,13 @@
 #include "kakounecli.hpp"
+#include <qprocess.h>
 
 KakouneCli::KakouneCli()
 {
-    QString session_id = "";
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    QString session_id = env.value("KAKQT_SESSION_ID") ;
 
     m_socket = new QLocalSocket();
-    m_socket->connectToServer("KakouneQt.543");
+    m_socket->connectToServer("KakouneQt." + session_id);
     if (!m_socket->waitForConnected()) {
         qDebug() << "Failed to connect to server:" << m_socket->errorString();
         return;

--- a/src/kakounecli.cpp
+++ b/src/kakounecli.cpp
@@ -31,6 +31,7 @@ int KakouneCli::run(QStringList command)
         }
         else
         {
+            // TODO add arguments
             // m_socket->write("newClient", command.sliced(1).join(" "));
             // m_socket->flush();
         }
@@ -41,8 +42,10 @@ int KakouneCli::run(QStringList command)
         {
             return 1;
         }
-        // m_socket->write("focusWindow", command[1]);
-        // m_socket->flush();
+        qDebug("FOCUS");
+        QString a = QString("{\"method\":\"focusWindow\",\"client_name\":\"%1\"}").arg(command[1]);
+        m_socket->write(a.toLocal8Bit());
+        m_socket->flush();
     }
     else
     {

--- a/src/kakounecli.cpp
+++ b/src/kakounecli.cpp
@@ -31,9 +31,9 @@ int KakouneCli::run(QStringList command)
         }
         else
         {
-            // TODO add arguments
-            // m_socket->write("newClient", command.sliced(1).join(" "));
-            // m_socket->flush();
+            QString request = QString("{\"method\":\"newClient\",\"args\":\"%1\"}").arg(command[1]);
+            m_socket->write(request.toLocal8Bit());
+            m_socket->flush();
         }
     }
     else if (command_name == "focus")
@@ -43,8 +43,8 @@ int KakouneCli::run(QStringList command)
             return 1;
         }
         qDebug("FOCUS");
-        QString a = QString("{\"method\":\"focusWindow\",\"client_name\":\"%1\"}").arg(command[1]);
-        m_socket->write(a.toLocal8Bit());
+        QString request = QString("{\"method\":\"focusWindow\",\"client_name\":\"%1\"}").arg(command[1]);
+        m_socket->write(request.toLocal8Bit());
         m_socket->flush();
     }
     else

--- a/src/kakounecli.cpp
+++ b/src/kakounecli.cpp
@@ -1,7 +1,20 @@
 #include "kakounecli.hpp"
 
-KakouneCli::KakouneCli(const QString &service_name) : m_dbusiface(service_name, "/")
+KakouneCli::KakouneCli()
 {
+    QString session_id = "";
+
+    m_socket = new QLocalSocket();
+    m_socket->connectToServer("KakouneQt.543");
+    if (!m_socket->waitForConnected()) {
+        qDebug() << "Failed to connect to server:" << m_socket->errorString();
+        return;
+    }
+}
+
+KakouneCli::~KakouneCli()
+{
+  m_socket->disconnectFromServer();
 }
 
 int KakouneCli::run(QStringList command)
@@ -11,11 +24,13 @@ int KakouneCli::run(QStringList command)
     {
         if (command.size() == 1)
         {
-            m_dbusiface.call("newClient");
+            m_socket->write("{\"method\":\"newClient\"}");
+            m_socket->flush();
         }
         else
         {
-            m_dbusiface.call("newClient", command.sliced(1).join(" "));
+            // m_socket->write("newClient", command.sliced(1).join(" "));
+            // m_socket->flush();
         }
     }
     else if (command_name == "focus")
@@ -24,7 +39,8 @@ int KakouneCli::run(QStringList command)
         {
             return 1;
         }
-        m_dbusiface.call("focusWindow", command[1]);
+        // m_socket->write("focusWindow", command[1]);
+        // m_socket->flush();
     }
     else
     {

--- a/src/kakounecli.hpp
+++ b/src/kakounecli.hpp
@@ -2,8 +2,8 @@
 #define KAKOUNECLI_HPP
 
 #include <QList>
-#include <QString>
 #include <QLocalSocket>
+#include <QString>
 
 class KakouneCli
 {

--- a/src/kakounecli.hpp
+++ b/src/kakounecli.hpp
@@ -3,17 +3,18 @@
 
 #include <QList>
 #include <QString>
-#include <qdbusinterface.h>
+#include <QLocalSocket>
 
 class KakouneCli
 {
   public:
-    KakouneCli(const QString &service_name);
+    KakouneCli();
+    ~KakouneCli();
 
     int run(QStringList command);
 
   private:
-    QDBusInterface m_dbusiface;
+    QLocalSocket *m_socket;
 };
 
 #endif

--- a/src/kakouneserver.cpp
+++ b/src/kakouneserver.cpp
@@ -1,0 +1,56 @@
+#include "kakouneserver.hpp"
+#include <QLocalSocket>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+KakouneServer::KakouneServer(const QString& session_id)
+{
+    m_server = new QLocalServer(this);
+
+    QString server_name = "KakouneQt.543";
+    if (!m_server->listen(server_name))
+    {
+      qDebug() << "Unable to start the server: " << m_server->errorString();
+      m_server->close();
+      return;
+    }
+
+    connect(m_server, &QLocalServer::newConnection, this, &KakouneServer::handleConnection);
+}
+
+KakouneServer::~KakouneServer()
+{
+    m_server->close();
+    delete m_server;
+}
+
+void KakouneServer::bind(MainWindow* main_window)
+{
+    connect(this, &KakouneServer::newClient, main_window, &MainWindow::newClient);
+}
+
+void KakouneServer::handleConnection()
+{
+    QLocalSocket *client_socket = m_server->nextPendingConnection();
+
+    connect(client_socket, &QLocalSocket::disconnected,
+            client_socket, &QLocalSocket::deleteLater);
+
+    if (client_socket->waitForReadyRead()) {
+        QByteArray request = client_socket->readAll();
+        QJsonObject request_json = QJsonDocument::fromJson(request).object();
+        qDebug() << request_json;
+
+        handleCommand(request_json);
+    }
+
+    client_socket->disconnectFromServer();
+}
+
+void KakouneServer::handleCommand(QJsonObject request)
+{
+    const QString method = request["method"].toString();
+    if (method == "newClient") {
+      emit newClient("");
+    }
+}

--- a/src/kakouneserver.cpp
+++ b/src/kakouneserver.cpp
@@ -51,7 +51,7 @@ void KakouneServer::handleCommand(QJsonObject request)
     const QString method = request["method"].toString();
     qDebug() << method;
     if (method == "newClient") {
-      emit newClient("");
+      emit newClient(request["args"].isString() ? request["args"].toString() : "");
     }else if (method == "focusWindow") {
       qDebug() << request["client_name"].toString();
       emit focusWindow(request["client_name"].toString());

--- a/src/kakouneserver.cpp
+++ b/src/kakouneserver.cpp
@@ -20,6 +20,7 @@ KakouneServer::KakouneServer(const QString& session_id)
 KakouneServer::~KakouneServer()
 {
     m_server->close();
+    QLocalServer::removeServer(m_server->serverName());
     delete m_server;
 }
 

--- a/src/kakouneserver.cpp
+++ b/src/kakouneserver.cpp
@@ -7,8 +7,7 @@ KakouneServer::KakouneServer(const QString& session_id)
 {
     m_server = new QLocalServer(this);
 
-    QString server_name = "KakouneQt.543";
-    if (!m_server->listen(server_name))
+    if (!m_server->listen(session_id))
     {
       qDebug() << "Unable to start the server: " << m_server->errorString();
       m_server->close();

--- a/src/kakouneserver.cpp
+++ b/src/kakouneserver.cpp
@@ -1,17 +1,17 @@
 #include "kakouneserver.hpp"
-#include <QLocalSocket>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QLocalSocket>
 
-KakouneServer::KakouneServer(const QString& session_id)
+KakouneServer::KakouneServer(const QString &session_id)
 {
     m_server = new QLocalServer(this);
 
     if (!m_server->listen(session_id))
     {
-      qDebug() << "Unable to start the server: " << m_server->errorString();
-      m_server->close();
-      return;
+        qDebug() << "Unable to start the server: " << m_server->errorString();
+        m_server->close();
+        return;
     }
 
     connect(m_server, &QLocalServer::newConnection, this, &KakouneServer::handleConnection);
@@ -24,20 +24,20 @@ KakouneServer::~KakouneServer()
     delete m_server;
 }
 
-void KakouneServer::bind(MainWindow* main_window)
+void KakouneServer::bind(MainWindow *main_window)
 {
     connect(this, &KakouneServer::newClient, main_window, &MainWindow::newClient);
-    connect(this, &KakouneServer::focusWindow , main_window, &MainWindow::focusWindow);
+    connect(this, &KakouneServer::focusWindow, main_window, &MainWindow::focusWindow);
 }
 
 void KakouneServer::handleConnection()
 {
     QLocalSocket *client_socket = m_server->nextPendingConnection();
 
-    connect(client_socket, &QLocalSocket::disconnected,
-            client_socket, &QLocalSocket::deleteLater);
+    connect(client_socket, &QLocalSocket::disconnected, client_socket, &QLocalSocket::deleteLater);
 
-    if (client_socket->waitForReadyRead()) {
+    if (client_socket->waitForReadyRead())
+    {
         QByteArray request = client_socket->readAll();
         QJsonObject request_json = QJsonDocument::fromJson(request).object();
 
@@ -51,10 +51,13 @@ void KakouneServer::handleCommand(QJsonObject request)
 {
     const QString method = request["method"].toString();
     qDebug() << method;
-    if (method == "newClient") {
-      emit newClient(request["args"].isString() ? request["args"].toString() : "");
-    }else if (method == "focusWindow") {
-      qDebug() << request["client_name"].toString();
-      emit focusWindow(request["client_name"].toString());
+    if (method == "newClient")
+    {
+        emit newClient(request["args"].isString() ? request["args"].toString() : "");
+    }
+    else if (method == "focusWindow")
+    {
+        qDebug() << request["client_name"].toString();
+        emit focusWindow(request["client_name"].toString());
     }
 }

--- a/src/kakouneserver.cpp
+++ b/src/kakouneserver.cpp
@@ -26,6 +26,7 @@ KakouneServer::~KakouneServer()
 void KakouneServer::bind(MainWindow* main_window)
 {
     connect(this, &KakouneServer::newClient, main_window, &MainWindow::newClient);
+    connect(this, &KakouneServer::focusWindow , main_window, &MainWindow::focusWindow);
 }
 
 void KakouneServer::handleConnection()
@@ -38,7 +39,6 @@ void KakouneServer::handleConnection()
     if (client_socket->waitForReadyRead()) {
         QByteArray request = client_socket->readAll();
         QJsonObject request_json = QJsonDocument::fromJson(request).object();
-        qDebug() << request_json;
 
         handleCommand(request_json);
     }
@@ -49,7 +49,11 @@ void KakouneServer::handleConnection()
 void KakouneServer::handleCommand(QJsonObject request)
 {
     const QString method = request["method"].toString();
+    qDebug() << method;
     if (method == "newClient") {
       emit newClient("");
+    }else if (method == "focusWindow") {
+      qDebug() << request["client_name"].toString();
+      emit focusWindow(request["client_name"].toString());
     }
 }

--- a/src/kakouneserver.hpp
+++ b/src/kakouneserver.hpp
@@ -1,0 +1,26 @@
+#ifndef KAKOUNESERVER_HPP
+#define KAKOUNESERVER_HPP
+
+#include "mainwindow.hpp"
+#include <QObject>
+#include <QLocalServer>
+
+class KakouneServer : public QObject
+{
+  Q_OBJECT
+  public:
+    KakouneServer(const QString& session_id);
+    ~KakouneServer();
+
+    void bind(MainWindow* main_window);
+  signals:
+    void newClient(const QString& arguments);
+  protected:
+    void handleConnection();
+    void handleCommand(QJsonObject request);
+  private:
+    QLocalServer *m_server;
+
+};
+
+#endif

--- a/src/kakouneserver.hpp
+++ b/src/kakouneserver.hpp
@@ -15,6 +15,7 @@ class KakouneServer : public QObject
     void bind(MainWindow* main_window);
   signals:
     void newClient(const QString& arguments);
+    void focusWindow(const QString& client_name);
   protected:
     void handleConnection();
     void handleCommand(QJsonObject request);

--- a/src/kakouneserver.hpp
+++ b/src/kakouneserver.hpp
@@ -2,26 +2,27 @@
 #define KAKOUNESERVER_HPP
 
 #include "mainwindow.hpp"
-#include <QObject>
 #include <QLocalServer>
+#include <QObject>
 
 class KakouneServer : public QObject
 {
-  Q_OBJECT
+    Q_OBJECT
   public:
-    KakouneServer(const QString& session_id);
+    KakouneServer(const QString &session_id);
     ~KakouneServer();
 
-    void bind(MainWindow* main_window);
+    void bind(MainWindow *main_window);
   signals:
-    void newClient(const QString& arguments);
-    void focusWindow(const QString& client_name);
+    void newClient(const QString &arguments);
+    void focusWindow(const QString &client_name);
+
   protected:
     void handleConnection();
     void handleCommand(QJsonObject request);
+
   private:
     QLocalServer *m_server;
-
 };
 
 #endif

--- a/src/kakounewidget.cpp
+++ b/src/kakounewidget.cpp
@@ -13,7 +13,8 @@ KakouneWidget::KakouneWidget(const QString &session_id, DrawOptions *draw_option
     m_id = QUuid::createUuid();
     m_draw_options = draw_options;
 
-    m_client = new KakouneClient(session_id, client_arguments, {{"KAKQT_SESSION_ID", session_id}, {"KAKQT_WINDOW_ID", m_id.toString()}});
+    m_client = new KakouneClient(session_id, client_arguments,
+                                 {{"KAKQT_SESSION_ID", session_id}, {"KAKQT_WINDOW_ID", m_id.toString()}});
     connect(m_client, &KakouneClient::refresh, this, &KakouneWidget::clientRefreshed);
     connect(m_client, &KakouneClient::finished, this, &KakouneWidget::finished);
     connect(m_client, &KakouneClient::setUIOptions, this, &KakouneWidget::setUIOptions);

--- a/src/kakounewidget.cpp
+++ b/src/kakounewidget.cpp
@@ -13,7 +13,7 @@ KakouneWidget::KakouneWidget(const QString &session_id, DrawOptions *draw_option
     m_id = QUuid::createUuid();
     m_draw_options = draw_options;
 
-    m_client = new KakouneClient(session_id, client_arguments, {{"KAKQT_WINDOW_ID", m_id.toString()}});
+    m_client = new KakouneClient(session_id, client_arguments, {{"KAKQT_SESSION_ID", session_id}, {"KAKQT_WINDOW_ID", m_id.toString()}});
     connect(m_client, &KakouneClient::refresh, this, &KakouneWidget::clientRefreshed);
     connect(m_client, &KakouneClient::finished, this, &KakouneWidget::finished);
     connect(m_client, &KakouneClient::setUIOptions, this, &KakouneWidget::setUIOptions);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,7 @@
 #include "kakounecli.hpp"
+#include "kakouneserver.hpp"
 #include "mainwindow.hpp"
 #include <QApplication>
-#include <QDBusConnection>
-#include <QDBusError>
-#include <QDBusInterface>
-#include <QDBusReply>
 
 #define DBUS_SERVICE_NAME "com.github.falbru.KakouneQt"
 
@@ -12,19 +9,9 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
-    auto connection = QDBusConnection::sessionBus();
-
-    if (!connection.isConnected())
-    {
-        qWarning("Cannot connect to the D-Bus session bus.\n"
-                 "To start it, run:\n"
-                 "\teval `dbus-launch --auto-syntax`\n");
-        return 1;
-    }
-
     if (argc > 1 && strcmp(argv[1], "cli") == 0)
     {
-        KakouneCli cli(DBUS_SERVICE_NAME);
+        KakouneCli cli;
 
         QStringList command;
         for (int i = 2; i < argc; i++)
@@ -35,14 +22,10 @@ int main(int argc, char *argv[])
         return cli.run(command);
     }
 
-    if (!connection.registerService(DBUS_SERVICE_NAME))
-    {
-        qWarning("%s\n", qPrintable(connection.lastError().message()));
-        return 1;
-    }
-
     MainWindow w;
-    connection.registerObject("/", &w, QDBusConnection::ExportAllSlots);
+
+    KakouneServer server("KakouneQt.123");
+    server.bind(&w);
 
     w.show();
     return app.exec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,11 @@
 
 #define DBUS_SERVICE_NAME "com.github.falbru.KakouneQt"
 
+QString generateRandomKakouneSessionId()
+{
+    return QString::number(QRandomGenerator::global()->bounded(1000, 9999));
+}
+
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
@@ -22,9 +27,10 @@ int main(int argc, char *argv[])
         return cli.run(command);
     }
 
-    MainWindow w;
+    QString session_id = generateRandomKakouneSessionId();
 
-    KakouneServer server("KakouneQt.123");
+    MainWindow w(session_id);
+    KakouneServer server("KakouneQt." + session_id);
     server.bind(&w);
 
     w.show();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,7 +11,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     m_session = new KakouneSession();
 
     m_root = new QSplitter(this);
-    this->newClient();
+    this->newClient("");
 
     setCentralWidget(m_root);
 }
@@ -23,11 +23,6 @@ MainWindow::~MainWindow()
 void MainWindow::closeEvent(QCloseEvent *ev)
 {
     delete m_session;
-}
-
-void MainWindow::newClient()
-{
-    newClient("");
 }
 
 void MainWindow::newClient(const QString &arguments)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,14 +1,14 @@
 #include "mainwindow.hpp"
 #include "keybindings.hpp"
 
-MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
+MainWindow::MainWindow(QString session_id, QWidget *parent) : QMainWindow(parent)
 {
     resize(1024, 768);
 
     m_draw_options = new DrawOptions();
     m_draw_options->setFont("monospace", 11);
 
-    m_session = new KakouneSession();
+    m_session = new KakouneSession(session_id);
 
     m_root = new QSplitter(this);
     this->newClient("");

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -12,7 +12,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
   public:
-    MainWindow(QWidget *parent = nullptr);
+    MainWindow(QString session_id, QWidget *parent = nullptr);
     ~MainWindow();
 
     void focusLeft();

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -19,7 +19,6 @@ class MainWindow : public QMainWindow
     void focusRight();
 
   public slots:
-    void newClient();
     void newClient(const QString &arguments);
     void focusWindow(const QString &uuid);
 


### PR DESCRIPTION
The problem with the DBus was that only one instance could be open at a time. This is now fixed by using `QLocalServer` and `QLocalSocket` instead