### PR TITLE
Fix bug for default color schemes in Kakoune

### DIFF
--- a/src/colorpalette.cpp
+++ b/src/colorpalette.cpp
@@ -2,14 +2,22 @@
 #include <qnamespace.h>
 
 ColorPalette::ColorPalette()
-    : m_gray(Qt::gray), m_red(Qt::red), m_green(Qt::green), m_yellow(Qt::yellow), m_blue(Qt::blue),
-      m_magenta(Qt::magenta), m_cyan(Qt::cyan), m_white(Qt::white)
+    : m_fg(Qt::white), m_bg(Qt::black), m_black(Qt::black), m_red(Qt::red), m_green(Qt::green), m_yellow(Qt::yellow),
+      m_blue(Qt::blue), m_magenta(Qt::magenta), m_cyan(Qt::cyan), m_white(Qt::white)
 {
 }
 
-void ColorPalette::setGray(QColor color)
+void ColorPalette::setFg(QColor color)
 {
-    m_gray = color;
+    m_fg = color;
+}
+void ColorPalette::setBg(QColor color)
+{
+    m_bg = color;
+}
+void ColorPalette::setBlack(QColor color)
+{
+    m_black = color;
 }
 void ColorPalette::setRed(QColor color)
 {
@@ -40,9 +48,17 @@ void ColorPalette::setWhite(QColor color)
     m_white = color;
 }
 
-QColor ColorPalette::getGray() const
+QColor ColorPalette::getFg() const
 {
-    return m_gray;
+    return m_fg;
+}
+QColor ColorPalette::getBg() const
+{
+    return m_bg;
+}
+QColor ColorPalette::getBlack() const
+{
+    return m_black;
 }
 QColor ColorPalette::getRed() const
 {

--- a/src/colorpalette.hpp
+++ b/src/colorpalette.hpp
@@ -9,7 +9,9 @@ class ColorPalette
   public:
     ColorPalette();
 
-    void setGray(QColor color);
+    void setFg(QColor color);
+    void setBg(QColor color);
+    void setBlack(QColor color);
     void setRed(QColor color);
     void setGreen(QColor color);
     void setYellow(QColor color);
@@ -18,7 +20,9 @@ class ColorPalette
     void setCyan(QColor color);
     void setWhite(QColor color);
 
-    QColor getGray() const;
+    QColor getFg() const;
+    QColor getBg() const;
+    QColor getBlack() const;
     QColor getRed() const;
     QColor getGreen() const;
     QColor getYellow() const;
@@ -28,7 +32,9 @@ class ColorPalette
     QColor getWhite() const;
 
   private:
-    QColor m_gray;
+    QColor m_fg;
+    QColor m_bg;
+    QColor m_black;
     QColor m_red;
     QColor m_green;
     QColor m_yellow;

--- a/src/kakouneinfobox.cpp
+++ b/src/kakouneinfobox.cpp
@@ -166,7 +166,7 @@ void KakouneInfoBox::paintEvent(QPaintEvent *ev)
 
     DrawContext context{painter, m_draw_options->getColorPalette(), m_draw_options->getCellSize()};
 
-    painter.fillRect(0, 0, width(), height(), m_client->getInfoFace().getBg().toQColor(context.color_palette));
+    painter.fillRect(0, 0, width(), height(), m_client->getInfoFace().getBgAsQColor(context.color_palette));
 
     RPC::Line title = m_client->getInfoTitle();
     if (title.contentSize() > 0)

--- a/src/kakounemenu.cpp
+++ b/src/kakounemenu.cpp
@@ -105,7 +105,7 @@ void KakouneMenu::paintEvent(QPaintEvent *ev)
 
     DrawContext context{painter, m_draw_options->getColorPalette(), m_draw_options->getCellSize()};
 
-    painter.fillRect(0, 0, width(), height(), m_client->getMenuFace().getBg().toQColor(context.color_palette));
+    painter.fillRect(0, 0, width(), height(), m_client->getMenuFace().getBgAsQColor(context.color_palette));
 
     QList<RPC::Line> items = m_client->getMenuItems();
 
@@ -124,7 +124,7 @@ void KakouneMenu::paintEvent(QPaintEvent *ev)
         if (m_selected_item == index)
         {
             painter.fillRect(position.x(), position.y(), item_width, item_height,
-                             m_client->getSelectedMenuItemFace().getBg().toQColor(context.color_palette));
+                             m_client->getSelectedMenuItemFace().getBgAsQColor(context.color_palette));
             items[index].draw(context, position, m_client->getSelectedMenuItemFace());
         }
         else

--- a/src/kakounetextedit.cpp
+++ b/src/kakounetextedit.cpp
@@ -45,8 +45,7 @@ void KakouneTextEdit::paintEvent(QPaintEvent *)
     DrawContext context{painter, m_draw_options->getColorPalette(), m_draw_options->getCellSize()};
 
     painter.setFont(m_draw_options->getFont());
-    painter.fillRect(
-        rect(), m_client->getDefaultFace().getBg().toQColor(m_client->getDefaultFace().getBg(), context.color_palette));
+    painter.fillRect(rect(), m_client->getDefaultFace().getBgAsQColor(context.color_palette));
 
     QList<RPC::Line> lines = m_client->getLines();
     for (int i = 0; i < lines.size(); ++i)

--- a/src/kakounewidget.cpp
+++ b/src/kakounewidget.cpp
@@ -98,45 +98,43 @@ void KakouneWidget::setUIOptions(QMap<QString, QString> options)
         }
         else if (option.key().length() > 13 && option.key().mid(0, 13) == "gui_set_color")
         {
-            auto setColor = [&](auto setColorFunc) {
-                ColorPalette new_color_palette = m_draw_options->getColorPalette();
-                (new_color_palette.*
-                 setColorFunc)(RPC::Color(option.value()).toQColor(m_draw_options->getColorPalette()));
-                m_draw_options->setColorPalette(new_color_palette);
-            };
+            ColorPalette color_palette = m_draw_options->getColorPalette();
+            RPC::Color value(option.value());
 
             if (option.key() == "gui_set_color_gray")
             {
-                setColor(&ColorPalette::setGray);
+                color_palette.setBlack(value.toQColor(color_palette, color_palette.getBlack()));
             }
             else if (option.key() == "gui_set_color_red")
             {
-                setColor(&ColorPalette::setRed);
+                color_palette.setRed(value.toQColor(color_palette, color_palette.getRed()));
             }
             else if (option.key() == "gui_set_color_green")
             {
-                setColor(&ColorPalette::setGreen);
+                color_palette.setGreen(value.toQColor(color_palette, color_palette.getGreen()));
             }
             else if (option.key() == "gui_set_color_yellow")
             {
-                setColor(&ColorPalette::setYellow);
+                color_palette.setYellow(value.toQColor(color_palette, color_palette.getYellow()));
             }
             else if (option.key() == "gui_set_color_blue")
             {
-                setColor(&ColorPalette::setBlue);
+                color_palette.setBlue(value.toQColor(color_palette, color_palette.getBlue()));
             }
             else if (option.key() == "gui_set_color_magenta")
             {
-                setColor(&ColorPalette::setMagenta);
+                color_palette.setMagenta(value.toQColor(color_palette, color_palette.getMagenta()));
             }
             else if (option.key() == "gui_set_color_cyan")
             {
-                setColor(&ColorPalette::setCyan);
+                color_palette.setCyan(value.toQColor(color_palette, color_palette.getCyan()));
             }
             else if (option.key() == "gui_set_color_white")
             {
-                setColor(&ColorPalette::setWhite);
+                color_palette.setWhite(value.toQColor(color_palette, color_palette.getWhite()));
             }
+
+            m_draw_options->setColorPalette(color_palette);
         }
         else
         {

--- a/src/rpc/atom.cpp
+++ b/src/rpc/atom.cpp
@@ -19,8 +19,8 @@ Face Atom::getFace()
 
 void Atom::draw(const DrawContext &context, const QPoint &position, const Face &default_face)
 {
-    QColor fg = m_face.getFg().toQColor(default_face.getFg(), context.color_palette);
-    QColor bg = m_face.getBg().toQColor(default_face.getBg(), context.color_palette);
+    QColor fg = m_face.getFgAsQColor(context.color_palette, default_face);
+    QColor bg = m_face.getBgAsQColor(context.color_palette, default_face);
 
     int width = context.cell_size.width() * m_contents.size();
     int height = context.cell_size.height();

--- a/src/rpc/color.cpp
+++ b/src/rpc/color.cpp
@@ -11,22 +11,17 @@ QString Color::getValue() const
     return m_value;
 }
 
-QColor Color::toQColor(const ColorPalette &color_palette)
-{
-    return toQColor(Color("black"), color_palette);
-}
-
-QColor Color::toQColor(const Color &default_color, const ColorPalette &color_palette)
+QColor Color::toQColor(const ColorPalette &color_palette, const QColor &fallback_color) const
 {
     QString color = m_value;
 
     if (color == "default")
     {
-        color = default_color.getValue();
+        return fallback_color;
     }
     else if (color == "black" || color == "bright-black")
     {
-        return color_palette.getGray();
+        return color_palette.getBlack();
     }
     else if (color == "red" || color == "bright-red")
     {

--- a/src/rpc/color.hpp
+++ b/src/rpc/color.hpp
@@ -13,8 +13,7 @@ class Color
     Color(QString value);
 
     QString getValue() const;
-    QColor toQColor(const ColorPalette &color_palette);
-    QColor toQColor(const Color &default_color, const ColorPalette &color_palette);
+    QColor toQColor(const ColorPalette &color_palette, const QColor &fallback_color) const;
 
   private:
     QString m_value;

--- a/src/rpc/face.cpp
+++ b/src/rpc/face.cpp
@@ -22,6 +22,26 @@ Color Face::getBg() const
     return m_bg;
 }
 
+QColor Face::getFgAsQColor(const ColorPalette &color_palette) const
+{
+    return getFg().toQColor(color_palette, color_palette.getFg());
+}
+
+QColor Face::getFgAsQColor(const ColorPalette &color_palette, const Face &default_face) const
+{
+    return getFg().toQColor(color_palette, default_face.getFgAsQColor(color_palette));
+}
+
+QColor Face::getBgAsQColor(const ColorPalette &color_palette) const
+{
+    return getBg().toQColor(color_palette, color_palette.getBg());
+}
+
+QColor Face::getBgAsQColor(const ColorPalette &color_palette, const Face &default_face) const
+{
+    return getBg().toQColor(color_palette, default_face.getBgAsQColor(color_palette));
+}
+
 bool Face::hasAttribute(Attribute attribute) const
 {
     return m_attributes.contains(attribute);

--- a/src/rpc/face.hpp
+++ b/src/rpc/face.hpp
@@ -15,6 +15,10 @@ class Face
 
     Color getFg() const;
     Color getBg() const;
+    QColor getFgAsQColor(const ColorPalette &color_palette) const;
+    QColor getFgAsQColor(const ColorPalette &color_palette, const Face &default_face) const;
+    QColor getBgAsQColor(const ColorPalette &color_palette) const;
+    QColor getBgAsQColor(const ColorPalette &color_palette, const Face &default_face) const;
 
     bool hasAttribute(Attribute attribute) const;
 

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -24,8 +24,7 @@ void StatusBar::paintEvent(QPaintEvent *ev)
     DrawContext context{painter, m_draw_options->getColorPalette(), m_draw_options->getCellSize()};
 
     RPC::Face status_default_face = m_client->getStatusDefaultFace();
-    painter.fillRect(
-        rect(), status_default_face.getBg().toQColor(status_default_face.getBg(), m_draw_options->getColorPalette()));
+    painter.fillRect(rect(), status_default_face.getBgAsQColor(m_draw_options->getColorPalette()));
 
     RPC::Line mode_line = m_client->getModeLine();
     int length = 0;


### PR DESCRIPTION
Previously, many faces were "invisible" for some of the default color schemes in Kakoune.

The default color scheme now:
![image](https://github.com/user-attachments/assets/b10d54e3-0c6b-4ed5-80ba-e0bed3469416)

Fixes #62 