### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Kakoune Qt is a Qt-based GUI for Kakoune written in C++
 1. Install the necessary build dependencies
 
 ```sh
-sudo apt install -y git build-essentials cmake qt6-base-dev qt6-svg-dev
+sudo apt install -y git build-essential cmake qt6-base-dev qt6-svg-dev
 ```
 
 2. Clone the repository
 
 ```sh
-git clone https://github.com/falbru/kakoune-qt ~/.config/kak/autoload/
+git clone https://github.com/falbru/kakoune-qt ~/.config/kak/autoload/kakoune-qt
 ```
 
 3. Build the project


### PR DESCRIPTION
Fixes two typos in the `README.md` that prevents users from building the project.
![Screenshot from 2024-08-03 12-05-39](https://github.com/user-attachments/assets/0d0a6f09-b9c6-4b6c-b7fd-a077836270fe)
