### PR TITLE
Fix RGBA values

### DIFF
--- a/src/rpc/color.cpp
+++ b/src/rpc/color.cpp
@@ -52,7 +52,17 @@ QColor Color::toQColor(const ColorPalette &color_palette, const QColor &fallback
         return Qt::white;
     }
 
-    QString hexCode = color.mid(color.indexOf(":") + 1);
+    int separatorIndex = color.indexOf(":");
+    QString colorFormat = color.mid(0, separatorIndex);
+    QString hexCode = color.mid(separatorIndex + 1);
+
+    if (colorFormat == "rgba")
+    {
+        QString rgbValue = hexCode.mid(0, 6);
+        QString alphaValue = hexCode.mid(6);
+        hexCode = alphaValue + rgbValue;
+    }
+
     return QColor("#" + hexCode);
 }
 } // namespace RPC


### PR DESCRIPTION
All RGBA values were incorrect, since Qt operates with the format AARRGGBB, while kakoune operates with RRGGBBAA

Before:
![image](https://github.com/user-attachments/assets/d6df379a-4f3e-41b7-9383-885db0b0b93e)

After:
![image](https://github.com/user-attachments/assets/3390c8aa-2b4e-407c-9bc8-3c9339834738)
