### PR TITLE
Fix crash for remote sessions

### DIFF
--- a/src/kakounesession.cpp
+++ b/src/kakounesession.cpp
@@ -75,15 +75,18 @@ KakouneSession::KakouneSession(QString session_id, QStringList session_arguments
 
 KakouneSession::~KakouneSession()
 {
-    QProcess kill_session;
-    kill_session.start("kak", {"-p", m_session_id});
-    kill_session.waitForStarted();
-    kill_session.write("kill");
-    kill_session.closeWriteChannel();
-    kill_session.waitForFinished();
-    kill_session.close();
+    if (m_process != nullptr)
+    {
+        QProcess kill_session;
+        kill_session.start("kak", {"-p", m_session_id});
+        kill_session.waitForStarted();
+        kill_session.write("kill");
+        kill_session.closeWriteChannel();
+        kill_session.waitForFinished();
+        kill_session.close();
 
-    m_process->close();
+        m_process->close();
+    }
 }
 
 QString KakouneSession::getSessionId()

--- a/src/kakounewidget.cpp
+++ b/src/kakounewidget.cpp
@@ -51,7 +51,6 @@ QSize KakouneWidget::sizeHint() const
 
 KakouneWidget::~KakouneWidget()
 {
-    delete m_client;
 }
 
 QUuid KakouneWidget::getID()


### PR DESCRIPTION
Remote sessions would crash since they tried to close the session process (which was null)